### PR TITLE
Use native fs.writeFile in lib/install/save.js

### DIFF
--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -13,7 +13,6 @@ const path = require('path')
 const stringifyPackage = require('stringify-package')
 const validate = require('aproba')
 const without = require('lodash.without')
-const writeFileAtomic = require('write-file-atomic')
 
 // if the -S|--save option is specified, then write installed packages
 // as dependencies to a package.json file.
@@ -129,7 +128,7 @@ function savePackageJson (tree, next) {
       log.verbose('shrinkwrap', 'skipping write for package.json because there were no changes.')
       next()
     } else {
-      writeFileAtomic(saveTarget, json, next)
+      fs.writeFile(saveTarget, json, next)
     }
   }))
 }


### PR DESCRIPTION
To write a file, write-file-atomic uses a temp file and replaces the original one by renaming the temp file to its original's name. 
In some cases this produces an EBUSY error, if the original file cannot be removed/replaced.
By using fs.writeFile this issue can be avoided, since it writes the given content directly into the original file and hence does not try to replace it.

Correct me if I'm wrong but I don't think there is a specific downside in using the native writeFile here.